### PR TITLE
Recover lost time for timers on repeat

### DIFF
--- a/Timer.lua
+++ b/Timer.lua
@@ -46,7 +46,7 @@ function Timer:update(dt)
         elseif timer.type == 'every' then
             if timer.time >= timer.delay then
                 timer.action()
-                timer.time = 0
+                timer.time = timer.time - timer.delay
                 timer.delay = self:__getResolvedDelay(timer.any_delay)
                 if timer.count > 0 then
                     timer.counter = timer.counter + 1


### PR DESCRIPTION
This patch will make it such that when the delay on a timer is not perfectly divisible by the delta time, it won't lose the time already accumulated beyond the delay itself. It also enables variable delta times to be used.