### PR TITLE
Fixes error that doesn't allow recursion with in timer:after()

### DIFF
--- a/Timer.lua
+++ b/Timer.lua
@@ -39,7 +39,7 @@ function Timer:update(dt)
 
         if timer.type == 'after' then
             if timer.time >= timer.delay then
-                timer.action()
+                timer.action(timer.action())
                 self.timers[tag] = nil
             end
 


### PR DESCRIPTION
In exercise 25 of your BYTEPATH tutorial, you can accomplish it with `hump.timer`, but not with `chrono.timer`. These changes allow for it just by passing itself through when it is called.